### PR TITLE
Add button to switch stations

### DIFF
--- a/src/commands/music/stop.ts
+++ b/src/commands/music/stop.ts
@@ -8,11 +8,14 @@ const { join } = require( "path" )
 const { AudioPlayerStatus, createAudioPlayer, createAudioResource, joinVoiceChannel, NoSubscriberBehavior } = require( "@discordjs/voice" )
 const { SlashCommandBuilder } = require( '@discordjs/builders' )
 
+// Import play command in case of switching stations
+const play = require( './play' )
+
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('stop')
 		.setDescription('Stop playing music!'),
-	async execute( client, interaction ) {
+	async execute( client, interaction, switchStation ) {
 
         const voiceChannel = interaction.member.voice
 
@@ -28,7 +31,9 @@ module.exports = {
 
             // Stop playing music
             connection.destroy()
-            await interaction.reply( 'Stopped playing music.' )
+            if(!switchStation) await interaction.reply( 'Stopped playing music.' )
+            // switch to new station
+            else await play.execute( client, interaction, switchStation ) 
         }
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,5 +66,13 @@ client.on('interactionCreate', async interaction => {
 	}
 })
 
+// If the Switch button is pressed, switch to the station chosen by the user
+client.on('interactionCreate', async interaction => {
+	if (! interaction.isButton()) return;
+    if(interaction.customId.split(' - ')[0] !== 'switch') await interaction.reply( { content: 'There was an error while executing this command!', ephemeral: true } )
+    const switchStation = interaction.customId.split(' - ').pop()
+    await client.commands.get('stop').execute( client, interaction, switchStation )
+});
+
 // Start the bot
 client.login(botconfig.token)


### PR DESCRIPTION
## Fixes #11 

## Changes Made:
- On receiving the `/play` command while playing music in the same channel, the bot offers the user a choice to switch to the new station, via a button
- When the user presses this Switch button, the current music is stopped, and the new station starts playing, along with an apt message from the bot

## Screenshot:
![image](https://user-images.githubusercontent.com/68962290/135838835-86137def-0b55-4ff8-b35a-7571dd81aedb.png)

I tested the new functionality by switching many times in a row, and also using the other commands. The `/nowplaying` command too works as expected and shows the new song after switching.

If there's any way the code can be improved, I'll be glad to do so!