### PR TITLE
Fix folder identification

### DIFF
--- a/src/commands/music/play.ts
+++ b/src/commands/music/play.ts
@@ -1,3 +1,5 @@
+import { folderExists } from "../../util";
+
 export{}
 
 // Node package imports //
@@ -18,7 +20,7 @@ module.exports = {
 
         const station = interaction.options.getString( 'station' ).toLowerCase()
 
-        if (! fs.existsSync( `../music/${station}`) ) {
+        if (! folderExists( `../music/${station}`) ) {
             return await interaction.reply( 'I could not find that radio station, are you sure it exists?' )
         }
         fs.readdirSync( `../music/${station}`, async ( err, files ) => {
@@ -101,6 +103,9 @@ function getTracks( station ) {
 
     // Create a promise that returns a list of all tracks in the music folder
     const promise = new Promise<String[]>((resolve, reject) => {
+        // reject the promise if the station doesn't exist
+        if (!folderExists(`../music/${station}`)) reject();
+
         let tracklist = []
         fs.readdir( `../music/${station}`, ( err, files ) => {
             if ( err ) console.log( err )

--- a/src/commands/music/stations.ts
+++ b/src/commands/music/stations.ts
@@ -1,4 +1,5 @@
 import {CommandInteraction, MessageEmbed} from "discord.js";
+import { folderExists } from "../../util";
 
 export{}
 
@@ -13,11 +14,15 @@ module.exports = {
     .setName('stations')
     .setDescription('Lists available stations to play!'),
   async execute( client, interaction: CommandInteraction) {
-    if (!fs.existsSync(this.musicFolder)) {
+    if (! folderExists(this.musicFolder)) {
       return await interaction.reply( "I couldn't find the music folder, are you sure it exists?" )
     }
     fs.readdir(this.musicFolder, ( err, stations ) => {
         if ( err ) console.log( err );
+
+        // filter out all files from the music folder
+        stations = stations.filter(station => folderExists(`../music/${station}`));
+
         if (!stations.length) {
           return interaction.reply("No stations found... Did you create any?")
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,10 @@
+import fs from "fs";
+
+/**
+ * Checks if a given path refers to a folder
+ * @param path the path to be checked
+ * @returns a boolean indicating if the path exists and refers to a folder
+ */
+export function folderExists(path: string): boolean {
+    return fs.existsSync(path) && fs.lstatSync(path).isDirectory();
+}


### PR DESCRIPTION
This PR fixes the issues described in #16 by
- creating a function `folderExists` in a new file `src/util.ts`
- swapping out the previous calls to `fs.existsSync` with calls to this function
- adding additional checks when accessing the contents of the music folder