### PR TITLE
Path library

### DIFF
--- a/src/commands/music/play.ts
+++ b/src/commands/music/play.ts
@@ -20,11 +20,12 @@ module.exports = {
 	async execute( client, interaction, switchStation ) {
 
         const station = interaction.options?.getString( 'station' )?.toLowerCase() || switchStation.toLowerCase()
+        const stationFolder = join(__dirname, ".." , "..", "..", "music", station);
 
-        if (! folderExists( `../music/${station}`) ) {
+        if (! folderExists(stationFolder) ) {
             return await interaction.reply( 'I could not find that radio station, are you sure it exists?' )
         }
-        fs.readdirSync( `../music/${station}`, async ( err, files ) => {
+        fs.readdirSync(stationFolder, async ( err, files ) => {
             if (! files ) {
                 return await interaction.reply( 'I could not find that radio station, are you sure it exists?' )
             }
@@ -90,13 +91,13 @@ module.exports = {
                 let trackPath = tracklist.shift()
 
                 playTrack( client, player, station, trackPath )
-    
+
                 // Idle event that fires when the bot is no longer playing a track
                 player.on( AudioPlayerStatus.Idle, async () => {
                     if ( tracklist.length == 0 ) {
                         return initPlayer()
                     }
-    
+
                     trackPath = tracklist.shift()
                     playTrack( client, player, station, trackPath )
                 })
@@ -114,11 +115,12 @@ function getTracks( station ) {
 
     // Create a promise that returns a list of all tracks in the music folder
     const promise = new Promise<String[]>((resolve, reject) => {
+        const stationFolder = join(__dirname, ".." , "..", "..", "music", station)
         // reject the promise if the station doesn't exist
-        if (!folderExists(`../music/${station}`)) reject();
+        if (!folderExists(stationFolder)) reject();
 
         let tracklist = []
-        fs.readdir( `../music/${station}`, ( err, files ) => {
+        fs.readdir(stationFolder, ( err, files ) => {
             if ( err ) console.log( err )
 
             let tracks = files.filter( f => f.split( '.' ).pop() === 'mp3' )
@@ -143,6 +145,6 @@ function playTrack( client, player, trackStation, trackPath ) {
     })
 
     // Create a new audio stream and play the track
-    const audio = createAudioResource( join( __dirname, `../../../music/${trackStation}/${trackPath}` ) )
+    const audio = createAudioResource(join( __dirname, "..", "..", "..", "music", trackStation, trackPath ))
     player.play( audio )
 }

--- a/src/commands/music/stations.ts
+++ b/src/commands/music/stations.ts
@@ -5,11 +5,11 @@ export{}
 
 // Node package imports //
 const fs = require( 'fs' )
-const path = require( "path" )
+const { join } = require( "path" )
 const { SlashCommandBuilder } = require( '@discordjs/builders' )
 
 module.exports = {
-  musicFolder: path.join(__dirname, "../../..", "music"),
+  musicFolder: join(__dirname, ".." , "..", "..", "music"),
   data: new SlashCommandBuilder()
     .setName('stations')
     .setDescription('Lists available stations to play!'),
@@ -21,7 +21,7 @@ module.exports = {
         if ( err ) console.log( err );
 
         // filter out all files from the music folder
-        stations = stations.filter(station => folderExists(`../music/${station}`));
+        stations = stations.filter(station => folderExists(join(this.musicFolder, station)));
 
         if (!stations.length) {
           return interaction.reply("No stations found... Did you create any?")


### PR DESCRIPTION
As discussed in PR #10, this PR migrates all path in the bot to use the "path" built-in library, for better cross-system compatibilites.

My suggestion for improvement of the repo, is defining linting rules with ESLint, so we can have more uniform code and a better coding experience overall.