### PR TITLE
Display stations in pages

### DIFF
--- a/src/commands/music/stations.ts
+++ b/src/commands/music/stations.ts
@@ -1,5 +1,7 @@
-import { CommandInteraction, MessageEmbed } from "discord.js";
-import { folderExists, stationExists } from "../../util";
+import { randomUUID } from "crypto";
+import { CommandInteraction, MessageActionRow, MessageButton, MessageEmbed } from "discord.js";
+import { copyFileSync } from "fs";
+import { folderExists, getStations, stationExists, STATIONS_LIST_MAX_ITEMS } from "../../util";
 
 export { }
 
@@ -8,36 +10,128 @@ const fs = require('fs')
 const { join } = require("path")
 const { SlashCommandBuilder } = require('@discordjs/builders')
 
+interface StationsMessage {
+  interaction: CommandInteraction,
+  page: number,
+  id: string
+}
+
+// this class keeps track of running /stations commands
+export class StationsInteractions {
+  static activeButtons: StationsMessage[] = [];
+
+  // get a StationsMessage object by ID
+  static getInteractionByID(id: string): StationsMessage {
+    for (let button of this.activeButtons) {
+      if (button.id === id) {
+        return button;
+      }
+    }
+  }
+
+  // increment the page index of the interaction matching the given ID and return the new page index
+  static incrementPage(id: string) {
+    for (let button of this.activeButtons) {
+      if (button.id === id) {
+        button.page++;
+        return button.page;
+      }
+    }
+  }
+
+  // insert a new StationsMessage object
+  static addInteraction(interaction: CommandInteraction, id: string) {
+    let newStationsMessage: StationsMessage = {
+      interaction: interaction,
+      id: id,
+      page: 0
+    };
+    this.activeButtons.push(newStationsMessage);
+  }
+}
+
 module.exports = {
   musicFolder: join(__dirname, "..", "..", "..", "music"),
   data: new SlashCommandBuilder()
     .setName('stations')
     .setDescription('Lists available stations to play!'),
-  async execute(client, interaction: CommandInteraction) {
+  async execute(client, interaction: CommandInteraction, lastInteractionID) {
     if (!folderExists(this.musicFolder)) {
       return await interaction.reply("I couldn't find the music folder, are you sure it exists?")
     }
-    fs.readdir(this.musicFolder, (err, stations) => {
-      if (err) console.log(err);
 
-      // filter out all files and invalid folders from the music folder
-      stations = stations.filter(station => stationExists(join(this.musicFolder, station)));
+    // if an lastInteractionID was given, use that to determine the page to display
+    // otherwise 0 if this is a direct call of /stations
+    let pageIdx;
+    if (lastInteractionID !== undefined) {
+      pageIdx = StationsInteractions.incrementPage(lastInteractionID);
+    } else {
+      pageIdx = 0;
+    }
 
-      if (!stations.length) {
-        return interaction.reply("No stations found... Did you create any?")
-      }
-
-      const stationsStr = stations.map((station) => {
+    // get the next page of stations
+    await getStations(this.musicFolder, pageIdx).then(async (stationsList) => {
+      // format the station names
+      const stationsStr = stationsList.stations.map((station) => {
         return `- ${this.capitalize(station)}`
       }).join("\n")
 
+      // create the list
       const stationsEmbed = new MessageEmbed()
-        .setTitle("Available stations:")
+        .setTitle(`Available stations, page ${pageIdx + 1}:`)
         .setDescription(stationsStr)
         .setFooter("Play one of these using /play");
+      
+      let row = new MessageActionRow();
 
-      interaction.reply({ embeds: [stationsEmbed] })
-    });
+      // add a button to show the next page if there are more stations to be displayed
+      if (stationsList.next) {
+        if (lastInteractionID === undefined) {
+          // if this is a direct call to /stations: generate a new UUID to identify this action
+          let uuid = randomUUID();
+          StationsInteractions.addInteraction(interaction, uuid);
+          row.addComponents(
+              new MessageButton()
+                .setCustomId(`stationsList - ${uuid}`)
+                .setLabel('Show next ' + STATIONS_LIST_MAX_ITEMS)
+                .setStyle('PRIMARY'),
+            );
+        } else {
+          // if this was the result of a button click, reuse the same interactionID
+          row.addComponents(
+              new MessageButton()
+                .setCustomId(`stationsList - ${lastInteractionID}`)
+                .setLabel('Show next ' + STATIONS_LIST_MAX_ITEMS)
+                .setStyle('PRIMARY'),
+            );
+          
+        }
+      } else {
+        // this is the last page => show a disabled button
+        row.addComponents(
+            new MessageButton()
+              .setCustomId("null")
+              .setLabel('No more stations to display')
+              .setDisabled(true)
+              .setStyle('SECONDARY'),
+          );
+      }
+
+      if (lastInteractionID !== undefined) {
+        // get the last message...
+        let editInteraction = StationsInteractions.getInteractionByID(lastInteractionID).interaction;
+        // and delete it
+        editInteraction.deleteReply();
+
+        // update the interaction, so the message sent below can be deleted later.
+        StationsInteractions.getInteractionByID(lastInteractionID).interaction = interaction;
+      }
+
+      // send a new list
+      await interaction.reply({ embeds: [stationsEmbed], components: [row] });
+    }).catch((err) => {
+      return interaction.reply(err)
+    })
   },
 
   capitalize(text: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import fs from 'fs'
 import DateTime from 'date-and-time'
 import { getVoiceConnection } from '@discordjs/voice'
+import { StationsInteractions } from './commands/music/stations'
 
 
 // Data files //
@@ -74,27 +75,32 @@ client.on('interactionCreate', async interaction => {
   }
 })
 
-// If the Switch button is pressed, switch to the station chosen by the user
 client.on('interactionCreate', async interaction => {
   if (!interaction.isButton()) return;
-  if (interaction.customId.split(' - ')[0] !== 'switch') await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true })
+  let cmd = interaction.customId.split(" - ")[0];
 
-  const [, switchStation, userID] = interaction.customId.split(' - ');
-  const member = await interaction.guild.members.fetch(interaction.user.id)
-  if (userID !== interaction.user.id) return await interaction.reply({ content: 'This button is only usable by the user that executed the command.', ephemeral: true })
+  if (cmd === "switch") {
+    // If the Switch button (/play command) is pressed, switch to the station chosen by the user
+    const [, switchStation, userID] = interaction.customId.split(' - ');
+    const member = await interaction.guild.members.fetch(interaction.user.id)
+    if (userID !== interaction.user.id) return await interaction.reply({ content: 'This button is only usable by the user that executed the command.', ephemeral: true })
 
-  if (member.voice && member.voice.channel) {
-    const connection = getVoiceConnection(member.voice.channel.guild.id)
-    if (connection) {
+    if (member.voice && member.voice.channel) {
+      const connection = getVoiceConnection(member.voice.channel.guild.id)
+      if (connection) {
 
-      interaction.update({ content: `Now playing music from: ${switchStation}`, components: [] })
+        interaction.update({ content: `Now playing music from: ${switchStation}`, components: [] })
 
-      await client.commands.get('stop').execute(client, interaction, switchStation)
+        await client.commands.get('stop').execute(client, interaction, switchStation)
+      } else {
+        await interaction.reply({ content: 'I\'m not playing music so I can\'t switch to another station!', ephemeral: true })
+      }
     } else {
-      await interaction.reply({ content: 'I\'m not playing music so I can\'t switch to another station!', ephemeral: true })
+      await interaction.reply({ content: 'You need to be in a voice channel to use this button!', ephemeral: true })
     }
-  } else {
-    await interaction.reply({ content: 'You need to be in a voice channel to use this button!', ephemeral: true })
+  } else if (cmd === "stationsList") {
+    // If the Next button (/stations command) is pressed, show the next stations
+    await client.commands.get("stations").execute(client, interaction, interaction.customId.split(" - ")[1]);
   }
 });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,10 @@
 import fs from "fs";
-import { basename } from "path";
+import { basename, join } from "path";
 
 // This limit is somewhat arbitrary, however some issues do arrise with too long station names.
 // Refer to issue #20
 const STATION_NAME_MAX_LENGTH = 50;
+export const STATIONS_LIST_MAX_ITEMS = 20;
 
 /**
  * Checks if a given path refers to a folder
@@ -21,4 +22,35 @@ export function folderExists(path: string): boolean {
  */
 export function stationExists(stationFolder: string): boolean {
   return folderExists(stationFolder) && basename(stationFolder).length <= STATION_NAME_MAX_LENGTH;
+}
+
+interface StationsList {
+  stations: string[],
+  next: boolean
+};
+
+/**
+ * Returns one page of stations. The amount of stations per page is determined by STATIONS_LIST_MAX_ITEMS.
+ * @param musicFolder path to the music folder
+ * @param page what page (as an index) should be returned
+ * @returns a StationsList object containing the next stations and if more stations are available
+ */
+export function getStations(musicFolder: string, page: number): Promise<StationsList> {
+  return new Promise((resolve, reject) => {
+    fs.readdir(musicFolder, (err, stations) => {
+      if (err) reject("Couldn't read music folder.");
+
+      // filter out all files and invalid folders from the music folder
+      stations = stations.filter(station => stationExists(join(musicFolder, station)));
+
+      if (stations.length == 0) reject("No stations found... Did you create any?")
+
+      let endIdx = (page + 1) * STATIONS_LIST_MAX_ITEMS;
+      let ret: StationsList = {
+        stations: stations.slice(page * STATIONS_LIST_MAX_ITEMS, endIdx), // select a subset of stations
+        next: stations.length >= (endIdx + 1) // check if there is at least one more station on the next page
+      };
+      resolve(ret);
+    });
+  })
 }


### PR DESCRIPTION
This PR modifies the /stations command to:
- only display up to 20 stations in one message
- send multiple messages (when the user requests it) until there are no more stations to be displayed

While it would have been ideal to only send one message and to update it to display more stations (as discussed in issue #27), this is not possible. The reason is that Discord requires the bot to reply to every interaction. Since a button click counts as an interaction, the bot has to respond with something when the user clicks a button, only editing a previous response is not enough and Discord throws an error. So instead a new message containing the next stations is sent and the previous reply is deleted.